### PR TITLE
Validate `skip` and `limit` Parameters in `GET / users / List Users` Endpoint

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -173,13 +173,20 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
-    total_users = await UserService.count(db)
-    users = await UserService.list_users(db, skip, limit)
 
+    # Validate skip and limit parameters
+    if skip < 0 or limit <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Parameters 'skip' and 'limit' must be non-negative integers. Received skip={skip} and limit={limit}."
+        )
+
+    total_users = await UserService.count(db)
+
+    users = await UserService.list_users(db, skip, limit)
     user_responses = [
         UserResponse.model_validate(user) for user in users
     ]
-    
     pagination_links = generate_pagination_links(request, skip, limit, total_users)
     
     # Construct the final response with pagination details

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -1,5 +1,6 @@
 from builtins import str
 import pytest
+from app.services.user_service import UserService
 from httpx import AsyncClient
 from app.main import app
 from app.models.user_model import User, UserRole
@@ -190,3 +191,39 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+# Tests for list_users skip & limit parameters
+@pytest.mark.asyncio
+async def test_list_users_invalid_skip_parameter(async_client: AsyncClient, admin_token: str):
+    response = await async_client.get(
+        "/users/?skip=-1",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 400
+    assert "Parameters 'skip' and 'limit' must be non-negative integers" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_list_users_invalid_limit_parameter(async_client: AsyncClient, admin_token: str):
+    response = await async_client.get(
+        "/users/?limit=0",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 400
+    assert "Parameters 'skip' and 'limit' must be non-negative integers" in response.json()["detail"]
+
+@pytest.fixture
+async def total_users(db_session):
+    # Replace with the actual way to count users in your database
+    count = await UserService.count(db_session)
+    return count
+
+@pytest.mark.asyncio
+async def test_list_users_valid_parameters(async_client: AsyncClient, admin_token: str):
+    response = await async_client.get(
+        "/users/?skip=0&limit=10",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    json_response = response.json()
+    assert 'items' in json_response
+    assert json_response["total"] >= len(json_response["items"])  # Assuming you have users in your test database


### PR DESCRIPTION
### Problem
The `GET /users` endpoint previously accepted invalid integers for `skip` and `limit` parameters. Specifically, it allowed negative values for `skip`, values of zero or less for `limit`, and values of `skip` that exceed the total number of users—all scenarios that did not correctly return a `400 Bad Request` response as expected.

### Solution
This pull request introduces validation checks for the `skip` and `limit` parameters within the `list_users` function:
- Ensures `skip` is a non-negative integer.
- Ensures `limit` is a positive integer.
- Returns a `400 Bad Request` with an informative error message if the validations fail.

### Additional Changes
- Implemented unit tests to cover new validation logic, ensuring the endpoint behaves as expected under various input scenarios.

### Impact
This update aims to make the `GET / users / List Users` endpoint more robust and user-friendly by preventing illogical or harmful requests and providing clearer feedback to the client.